### PR TITLE
Update build.gradle to build without secrets file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,22 +83,4 @@ publishing {
 		}
 	}
 
-	def secrets = new Properties()
-	file("secret.properties").withInputStream { secrets.load(it) }
-
-	// select the repositories you want to publish to
-	repositories {
-		// uncomment to publish to the local maven
-		// mavenLocal()
-		maven {
-            url "https://gitlab.com/api/v4/projects/20698805/packages/maven"
-            credentials(HttpHeaderCredentials) {
-                name = "Private-Token"
-                value = secrets.getProperty("gitLabPrivateToken") // the variable resides in ~/.gradle/gradle.properties
-            }
-            authentication {
-                header(HttpHeaderAuthentication)
-            }
-        }
-	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ version = project.mod_version
 group = project.maven_group
 
 configurations.all {
-    resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
+	resolutionStrategy.cacheChangingModulesFor 0, 'seconds'
 }
 
 repositories {
@@ -83,4 +83,25 @@ publishing {
 		}
 	}
 
+	if (file("./secret.properties").exists()) {
+		def secrets = new Properties()
+		file("secret.properties").withInputStream { secrets.load(it) }
+
+		// select the repositories you want to publish to
+		repositories {
+			// uncomment to publish to the local maven
+			// mavenLocal()
+			maven {
+				url "https://gitlab.com/api/v4/projects/20698805/packages/maven"
+				credentials(HttpHeaderCredentials) {
+					name = "Private-Token"
+					value = secrets.getProperty("gitLabPrivateToken")
+					// the variable resides in ~/.gradle/gradle.properties
+				}
+				authentication {
+					header(HttpHeaderAuthentication)
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Fixes a build error that occurs when the `secret.properties` file does not exist.